### PR TITLE
docs: Add `pauseOnHover` entry to props table

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Note that all props are optional.
 | reverse          | Boolean       | false              | Show notifications in reverse order                                                                                     |
 | ignoreDuplicates | Boolean       | false              | Ignore repeated instances of the same notification                                                                      |
 | closeOnClick     | Boolean       | true               | Close notification when clicked                                                                                         |
+| pauseOnHover     | Boolean       | false              | Keep the notification open while mouse hovers on notification                                                           |
 
 ### API
 


### PR DESCRIPTION
**Context**
The README.md file has a table which describes the props available on the `Notifications` component.

**Issue**
`pauseOnHover` is one of the props in [`Notifications.vue` file](https://github.com/kyvg/vue3-notification/blob/fa967ce72201abd0cfd417f0b7a133e1c0e71466/src/Notifications.vue), but is missing from the props table in the README file.

**Work done**
I added an entry to the props table in `README.md` to document the `pauseOnHover` functionality.

**Testing instructions**
N/A - These changes document current functionality; no testing necessary.

## Changes in PR:
Added an entry to the props table in `README.md` to document the `pauseOnHover` functionality.
