### PR TITLE
Fix README about composition API closing

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ notification.notify({
   text: 'This message will be removed immediately'
 })
 
-notification.close(id)
+notification.notify.close(id)
 
 ```
 


### PR DESCRIPTION
Fix typo in README about notification closing with composition API

Or I can make a PR to change the API to support the README example