### PR TITLE
fix: move `types` to `exports`

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
     "preversion": "npm run test && npm run release && git add -A dist"
   },
   "typings": "./dist/index.d.ts",
-  "types": "./dist/index.d.ts",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",
   "style": "./dist/index.css",
   "exports": {
+    "types": "./dist/index.d.ts",
     "import": "./dist/index.es.js",
     "require": "./dist/index.umd.js"
   },


### PR DESCRIPTION
## Changes in PR:

Fix declaration file

## Error:

```sh
error TS7016: Could not find a declaration file for module '@kyvg/vue3-notification'. '/path/to/project/node_modules/.pnpm/@kyvg+vue3-notification@2.9.0_vue@3.3.2/node_modules/@kyvg/vue3-notification/dist/index.es.js' implicitly has an 'any' type.
  There are types at '/path/to/project/modules/frontend/node_modules/@kyvg/vue3-notification/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@kyvg/vue3-notification' library may need to update its package.json or typings.

import { notify } from "@kyvg/vue3-notification";
```