### PR TITLE
Fix transition tag name

### DIFF
--- a/src/components/group/CssGroup.tsx
+++ b/src/components/group/CssGroup.tsx
@@ -12,7 +12,7 @@ export default defineComponent(
     },
     setup: (props, { slots }) => {
       return () => (
-        <TransitionGroup tag='name' name={props.name}>{
+        <TransitionGroup tag='div' name={props.name}>{
           slots.default?.()
         }</TransitionGroup>
       );

--- a/src/components/group/VelocityGroup.tsx
+++ b/src/components/group/VelocityGroup.tsx
@@ -40,7 +40,7 @@ export default defineComponent(
 
       return () => (
         <TransitionGroup 
-          tag='name' 
+          tag='div' 
           css={false} 
           name={props.name} 
           onEnter={handleEnter}


### PR DESCRIPTION
## Changes in PR:

- Set the tag of the `TransitionGroup` component to `div` (the current value , `name`, is not a valid HTML tag)