### PR TITLE
Fix typings (extend `vue` instead of `@vue/runtime-core`)

### DIFF
--- a/src/global-extensions.d.ts
+++ b/src/global-extensions.d.ts
@@ -1,6 +1,6 @@
 import { notify } from './index';
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
     export interface ComponentCustomProperties {
         $notify: typeof notify;
     }


### PR DESCRIPTION
## Changes in PR:

Switched to extending `vue` instead of `@vue/runtime-core` as recommended in the official docs. Currently, it breaks type checking and throws a lot of type errors when this library is included.

https://vuejs.org/guide/extras/web-components#web-components-and-typescript

Also, it would be great if dependencies could be updated. @kyvg let me know if you'd like me to open another PR for it but I don't know if there are any restrictions or things to watch out for with this library.