### PR TITLE
Allow string | number ids in NotificationsOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,18 +516,25 @@ computed: {
 }
 ```
 
-## Programatically Closing
+## Programmatically Closing
 
 ```javascript
-
-const id = Date.now() // This can be any unique number
+// You can use either a number or a string as a unique ID
+const id = Date.now();
+const strId = 'custom-notification-42';
 
 this.$notify({
-  id,
-  text: 'This message will be removed immediately'
+    id,
+    text: 'This message will be removed immediately'
+});
+
+this.$notify({
+    id: strId,
+    text: 'This message will also be removed immediately'
 });
 
 this.$notify.close(id);
+this.$notify.close(strId);
 ```
 
 Or with composition API style:
@@ -535,16 +542,17 @@ Or with composition API style:
 ```javascript
 import { useNotification } from "@kyvg/vue3-notification"
 
-const notification = useNotification()
+const { notify } = useNotification();
 
-const id = Date.now() // This can be any unique number
+// IDs can be numbers or strings
+const id = Date.now();
+const strId = 'custom-notification-42';
 
-notification.notify({
-  id,
-  text: 'This message will be removed immediately'
-})
+notify({ id, text: 'Numeric ID example' })
+notify({ id: strId, text: 'String ID example' })
 
-notification.notify.close(id)
+notify.close(id);
+notify.close(strId);
 
 ```
 

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -213,7 +213,7 @@ close: () => void;
 }>, {}, {}, string, ComponentProvideOptions, true, {}, any>;
 
 export declare interface NotificationsOptions {
-    id?: number;
+    id?: number | string;
     title?: string;
     text?: string;
     type?: NotificationType;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 type NotificationType = 'warn' | 'success' | 'error' | (string & {});
 
 export interface NotificationsOptions {
-  id?: number;
+  id?: number | string;
   title?: string;
   text?: string;
   type?: NotificationType;


### PR DESCRIPTION
This update extends the id property in `NotificationsOptions` from `number` to `string | number`.
It allows applications that use string-based identifiers (such as UUIDs, database keys, or prefixed IDs) to manage notifications programmatically without type casting or conversion.

Rationale:
- Some applications naturally use string IDs for entities and notifications.
- The current numeric-only type requires unnecessary conversions and limits flexibility.
- The internal implementation only compares IDs via strict equality (===), so supporting both types introduces no behavior change or compatibility issues.

Impact:
✅ Backward-compatible: existing numeric IDs continue to work.
✅ No runtime logic changes: ID handling remains equality-based.
✅ Documentation updated accordingly.

Example usage:
```
notify({ id: 123, text: 'Numeric ID example' });
notify({ id: 'uuid-123', text: 'String ID example' });
notify.close('uuid-123');
```

@kyvg 